### PR TITLE
Fixed panic caused by deleting from an empty buffer

### DIFF
--- a/agda-tac/src/file_io.rs
+++ b/agda-tac/src/file_io.rs
@@ -99,6 +99,10 @@ impl Repl {
     }
 
     pub fn remove_last_line_buffer(&mut self) {
+        if self.file_buf.len_lines() < 2 {
+            eprintln!("Error: line buffer is empty");
+            return;
+        }
         let line_last = self.file_buf.len_lines() - 2;
         let line_start = self.file_buf.line_to_char(line_last);
         let doc_end = self.file_buf.len_chars();

--- a/agda-tac/src/file_io.rs
+++ b/agda-tac/src/file_io.rs
@@ -131,7 +131,7 @@ impl Repl {
         let line_num = interval.start.line - 1;
         let line_start = self.file_buf.line_to_char(line_num);
         let line = self.file_buf.line(line_num);
-        let (idx, _) = (line.chars().into_iter().enumerate()).find(|(_, c)| c == &'=')?;
+        let (idx, _) = line.chars().enumerate().find(|(_, c)| c == &'=')?;
         self.file_buf.insert_char(line_start + idx, ' ');
         self.file_buf.insert(line_start + idx, text);
         Some(())

--- a/src/resp/di.rs
+++ b/src/resp/di.rs
@@ -80,12 +80,17 @@ pub struct ModuleContents {
 }
 
 #[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct TCWarning {
+    pub message: String,
+}
+
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AllGoalsWarnings {
     pub visible_goals: Vec<VisibleGoal>,
     pub invisible_goals: Vec<InvisibleGoal>,
-    pub warnings: Vec<String>,
-    pub errors: Vec<String>,
+    pub warnings: Vec<TCWarning>,
+    pub errors: Vec<TCWarning>,
 }
 
 /// Something that is displayed in the Emacs mode,

--- a/src/resp/mod.rs
+++ b/src/resp/mod.rs
@@ -216,4 +216,36 @@ mod test {
             _ => panic!("Expected Status response"),
         }
     }
+
+    #[test]
+    fn deserialize_displayinfo2() {
+        let json = r#"{
+            "info":{
+                "errors":[
+                    {
+                        "message":"/repo/agda-mode/agda-tac/Demo.agda:6.1-7: error: [MissingDefinitions]\nThe following names are declared but not accompanied by a\ndefinition: lemma2"
+                    }
+                ],
+                "invisibleGoals":[],
+                "kind":"AllGoalsWarnings",
+                "visibleGoals":[],
+                "warnings":[]
+            },
+            "kind":"DisplayInfo"
+        }"#;
+        let resp: Resp = serde_json::from_str(json).unwrap();
+        match resp {
+            Resp::DisplayInfo { info } => {
+                assert!(
+                    matches!(info.unwrap(), DisplayInfo::AllGoalsWarnings(AllGoalsWarnings {
+                    visible_goals,
+                    invisible_goals,
+                    warnings,
+                    errors,
+                }) if visible_goals.is_empty() && invisible_goals.is_empty() && warnings.is_empty() && errors.len() == 1)
+                );
+            }
+            _ => panic!("Expected DisplayInfo response"),
+        }
+    }
 }


### PR DESCRIPTION

- Fixed an issue where attempting to delete the last line when `file_buf` was empty caused a panic.
    
    > λ> line-pop
    > No goals.
    > λ> line-pop
    > thread 'main' panicked at agda-tac/src/file_io.rs:103:30:
    > attempt to subtract with overflow
    > note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

- Fixed tye type of `AllGoalsWarnings::warnings, errors` from `String` to `{ message: String }`

    

